### PR TITLE
Fix return value errors in `artisan-console.md`

### DIFF
--- a/digging-deeper/artisan-console.md
+++ b/digging-deeper/artisan-console.md
@@ -156,10 +156,9 @@ In addition to arguments and options, you may also prompt the user for input dur
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-  name := ctx.Ask("What is your name?")
-  email := ctx.Ask("What is your email address?")
-
-  return nil
+  email, err := ctx.Ask("What is your email address?")
+  
+  return err
 }
 ```
 
@@ -167,11 +166,11 @@ Additionally, you can pass options to the `Ask` method as optional second argume
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-    name := ctx.Ask("What is your name?", console.AskOption{
+    name, err := ctx.Ask("What is your name?", console.AskOption{
         Default: "Krishan",
     })
     
-    return nil
+    return err
 }
 
 // Available options
@@ -199,7 +198,7 @@ Sometimes you may need to hide the user input, such as when prompting for a pass
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-    password := ctx.Secret("What is the password?", console.SecretOption{
+    password, err := ctx.Secret("What is the password?", console.SecretOption{
         Validate: func (s string) error {
             if len(s) < 8 {
                 return errors.New("password length should be at least 8")
@@ -208,7 +207,7 @@ func (receiver *SendEmails) Handle(ctx console.Context) error {
         },
     })
     
-    return nil
+    return err
 }
 
 // Available options
@@ -231,7 +230,7 @@ type SecretOption struct {
 If you need to ask the user to confirm an action before proceeding, you may use the `Confirm` method. By default, this method will return `false` unless the user select affirmative option.
 
 ```go
-if !ctx.Confirm("Do you wish to continue?") {
+if answer, _ := ctx.Confirm("Do you wish to continue?"); !answer {
     // ...
 }
 ```
@@ -239,8 +238,10 @@ if !ctx.Confirm("Do you wish to continue?") {
 You can also pass a second argument to the `Confirm` method to customize the default value, label of the affirmative and negative buttons:
 
 ```go
-if !ctx.Confirm("Do you wish to continue?", console.ConfirmOption{
+if answer, _ := ctx.Confirm("Do you wish to continue?", console.ConfirmOption; !answer {
 	Default : true,
+	Affirmative : "Yes",
+	Negative : "No",
 }) {
     // ...
 }

--- a/zh/digging-deeper/artisan-console.md
+++ b/zh/digging-deeper/artisan-console.md
@@ -156,10 +156,9 @@ go run . artisan emails name --lang Chinese name
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-  name := ctx.Ask("What is your name?")
-  email := ctx.Ask("What is your email address?")
+  email, err := ctx.Ask("What is your email address?")
 
-  return nil
+  return err
 }
 ```
 
@@ -167,11 +166,11 @@ func (receiver *SendEmails) Handle(ctx console.Context) error {
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-    name := ctx.Ask("What is your name?", console.AskOption{
+    name, err := ctx.Ask("What is your name?", console.AskOption{
         Default: "Krishan",
     })
     
-    return nil
+    return err
 }
 
 // 可用选项
@@ -199,7 +198,7 @@ type AskOption struct {
 
 ```go
 func (receiver *SendEmails) Handle(ctx console.Context) error {
-    password := ctx.Secret("What is the password?", console.SecretOption{
+    password, err := ctx.Secret("What is the password?", console.SecretOption{
         Validate: func (s string) error {
             if len(s) < 8 {
                 return errors.New("password length should be at least 8")
@@ -208,7 +207,7 @@ func (receiver *SendEmails) Handle(ctx console.Context) error {
         },
     })
     
-    return nil
+    return err
 }
 
 // 可用选项
@@ -231,7 +230,7 @@ type SecretOption struct {
 如果你需要在继续之前要求用户确认操作，你可以使用 `Confirm` 方法。默认情况下，除非用户选择肯定选项，否则此方法将返回 `false`。
 
 ```go
-if !ctx.Confirm("Do you wish to continue?") {
+if answer, _ := ctx.Confirm("Do you wish to continue?"); !answer {
     // ...
 }
 ```
@@ -239,8 +238,10 @@ if !ctx.Confirm("Do you wish to continue?") {
 你还可以传递第二个参数给 `Confirm` 方法：
 
 ```go
-if !ctx.Confirm("Do you wish to continue?", console.ConfirmOption{
+if answer, _ := ctx.Confirm("Do you wish to continue?", console.ConfirmOption; !answer {
 	Default : true,
+	Affirmative : "确认",
+	Negative : "取消",
 }) {
     // ...
 }


### PR DESCRIPTION
## 📑 Description

`ctx.Ask`, `ctx.Confirm`, `ctx.Secret` all have two return values and cannot be directly judged

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
