### PR TITLE
Shallow clone as history is not needed in .git

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -22,7 +22,7 @@ goravel new blog
 
 ```shell
 // Download framework
-git clone https://github.com/goravel/goravel.git && rm -rf goravel/.git*
+git clone --depth=1 https://github.com/goravel/goravel.git && rm -rf goravel/.git*
 
 // Install dependencies
 cd goravel && go mod tidy

--- a/zh/getting-started/installation.md
+++ b/zh/getting-started/installation.md
@@ -23,7 +23,7 @@ goravel new blog
 
 ```shell
 // 下载框架
-git clone https://github.com/goravel/goravel.git && rm -rf goravel/.git*
+git clone --depth=1 https://github.com/goravel/goravel.git && rm -rf goravel/.git*
 
 // 安装依赖
 cd goravel && go mod tidy


### PR DESCRIPTION
## 📑 Description

If we delete the `.git` directory then we don't need to clone the whole history of the repository. `--depth=1` will clone the latest state of the repo.


