### PR TITLE
docs: add v1.17.3 upgrade notes

### DIFF
--- a/en/the-basics/logging.md
+++ b/en/the-basics/logging.md
@@ -14,6 +14,8 @@ To configure various log channels, custom configurations can be made in `config/
 
 The `print` configuration in `single` and `daily` drivers can control log output to the console.
 
+The `level` configuration controls the minimum log level. Logs below this level will be filtered out. Available levels are `debug` (default), `info`, `warning`, and `error`.
+
 ## Available channel drivers
 
 | Name     | Description             |

--- a/en/upgrade/v1.17.md
+++ b/en/upgrade/v1.17.md
@@ -51,6 +51,7 @@
 - [Fix routes registered in ServiceProvider.Boot() silently discarded when WithMiddleware() is used](#fix-routes-registered-in-serviceproviderboot-silently-discarded-when-withmiddleware-is-used)
 - [Fix Request InputArray splitting single values with spaces](#fix-request-inputarray-splitting-single-values-with-spaces)
 - [Fix generator imports for multi-segment module paths](#fix-generator-imports-for-multi-segment-module-paths)
+- [Fix LOG_LEVEL not being respected](#fix-log_level-not-being-respected)
 
 ## Upgrade Guide
 
@@ -609,3 +610,11 @@ goravel/framework: v1.17.3
 Previously, generators such as `make:migration`, `make:test`, and package scaffolding could generate imports using only the last segment of a multi-segment `go.mod` module path. Now generated imports use the full module path, such as `github.com/example/project/app/facades`.
 
 Issue: [#973](https://github.com/goravel/goravel/issues/973)
+
+### Fix LOG_LEVEL not being respected
+
+goravel/framework: v1.17.3
+
+Previously, setting `LOG_LEVEL=error` had no effect — info and debug messages were still written because `Writer.log()` bypassed the level check. Now the configured `LOG_LEVEL` is correctly consulted before writing any log entry.
+
+Issue: [#977](https://github.com/goravel/goravel/issues/977)

--- a/en/upgrade/v1.17.md
+++ b/en/upgrade/v1.17.md
@@ -45,6 +45,12 @@
 
 - [Fix the migrate:rollback command](#fix-the-migrate-rollback-command)
 
+## v1.17.3
+
+- [Fix Schema connection driver selection](#fix-schema-connection-driver-selection)
+- [Fix Request InputArray splitting single values with spaces](#fix-request-inputarray-splitting-single-values-with-spaces)
+- [Fix generator imports for multi-segment module paths](#fix-generator-imports-for-multi-segment-module-paths)
+
 ## Upgrade Guide
 
 As [Golang v1.23 is no longer maintained](https://endoflife.date/go), the Golang version of Goravel supports has been upgraded from 1.23 to 1.24.
@@ -568,3 +574,29 @@ When the queue worker concurrency is greater than 1, delay tasks will be execute
 goravel/framework: v1.17.2
 
 Previously, the `migrate:rollback` command set the batch number of rolled back migrations to 1 as default, which caused issues when rolling back. Now the command will set the batch number to the last batch number instead of 1.
+
+### Fix Schema connection driver selection
+
+goravel/framework: v1.17.3
+
+Previously, `facades.Schema().Connection(name)` used the selected connection but still compiled schema queries with the default connection's driver. Now schema operations such as `HasTable` and `db:wipe --database` use the selected connection's driver, grammar, processor, table prefix, and schema metadata.
+
+Issue: [#942](https://github.com/goravel/goravel/issues/942)
+
+### Fix Request InputArray splitting single values with spaces
+
+goravel/gin: v1.17.1
+
+goravel/fiber: v1.17.1
+
+Previously, `ctx.Request().InputArray` could split a single form or urlencoded array value containing spaces into multiple entries. Now a single submitted value such as `123 456 789` remains one array element, while multi-value arrays keep their existing behavior.
+
+Issue: [#961](https://github.com/goravel/goravel/issues/961)
+
+### Fix generator imports for multi-segment module paths
+
+goravel/framework: v1.17.3
+
+Previously, generators such as `make:migration`, `make:test`, and package scaffolding could generate imports using only the last segment of a multi-segment `go.mod` module path. Now generated imports use the full module path, such as `github.com/example/project/app/facades`.
+
+Issue: [#973](https://github.com/goravel/goravel/issues/973)

--- a/en/upgrade/v1.17.md
+++ b/en/upgrade/v1.17.md
@@ -48,6 +48,7 @@
 ## v1.17.3
 
 - [Fix Schema connection driver selection](#fix-schema-connection-driver-selection)
+- [Fix routes registered in ServiceProvider.Boot() silently discarded when WithMiddleware() is used](#fix-routes-registered-in-serviceproviderboot-silently-discarded-when-withmiddleware-is-used)
 - [Fix Request InputArray splitting single values with spaces](#fix-request-inputarray-splitting-single-values-with-spaces)
 - [Fix generator imports for multi-segment module paths](#fix-generator-imports-for-multi-segment-module-paths)
 
@@ -582,6 +583,14 @@ goravel/framework: v1.17.3
 Previously, `facades.Schema().Connection(name)` used the selected connection but still compiled schema queries with the default connection's driver. Now schema operations such as `HasTable` and `db:wipe --database` use the selected connection's driver, grammar, processor, table prefix, and schema metadata.
 
 Issue: [#942](https://github.com/goravel/goravel/issues/942)
+
+### Fix routes registered in ServiceProvider.Boot() silently discarded when WithMiddleware() is used
+
+goravel/framework: v1.17.3
+
+Previously, when global middleware was registered via `WithMiddleware()` in `bootstrap/app.go`, `configureMiddleware()` ran after `Boot()`, which rebuilt the route engine and discarded any routes registered by service providers during `Boot()`. Now `configureMiddleware()` is moved to run between `Register()` and `Boot()`, ensuring provider-registered routes survive the engine rebuild.
+
+Issue: [#975](https://github.com/goravel/goravel/issues/975)
 
 ### Fix Request InputArray splitting single values with spaces
 


### PR DESCRIPTION
## Summary
- Document the v1.17.3 patch release in the v1.17 upgrade guide.
- Cover the schema connection driver, request `InputArray`, and generator import path fixes.
- Link each fix to its related Goravel issue.

## Why
The v1.17 upgrade guide should show patch-level fixes so users can understand what changes after moving from v1.17.2 to v1.17.3. This update makes the release notes point to the reported issues and describes the corrected behavior for each fix.

The notes cover schema operations using the selected connection driver, request arrays preserving single values with spaces, and generators using full multi-segment Go module import paths. Related issues: https://github.com/goravel/goravel/issues/942, https://github.com/goravel/goravel/issues/961, https://github.com/goravel/goravel/issues/973.